### PR TITLE
change sparse matrices solver

### DIFF
--- a/rtv2.py
+++ b/rtv2.py
@@ -1,7 +1,9 @@
 import numpy as np
 import cv2
 from scipy.sparse import spdiags, csr_matrix
-from scipy.sparse.linalg import spsolve
+# from scipy.sparse.linalg import spsolve
+from pypardiso import spsolve
+
 
 
 def tsmooth(I, lambda_=0.01, sigma=3.0, sharpness=0.02, maxIter=4):
@@ -90,7 +92,7 @@ def solveLinearEquation(IN, wx, wy, lambda_):
     OUT = np.zeros_like(IN)
     for i in range(ch):
         tin = IN[:, :, i].ravel(order="F")
-        tout = spsolve(A, tin)
+        tout = spsolve(A.astype(np.float64), tin.astype(np.float64))
         OUT[:, :, i] = tout.reshape((r, c), order="F")
 
     return OUT


### PR DESCRIPTION
After testing PyPardiso spsolve for RTV, The operation was done a lot faster than previous code!
In Case of Lenna image spended time for 2 iteration RTV is : 
![image](https://github.com/guchengxi1994/RTV-in-Python/assets/59480858/3e7aa427-e91b-43f8-ab74-fd5ac4c2042e)

Further information about PyPardiso : https://pypi.org/project/pypardiso/  